### PR TITLE
Improve AVSIM link detection & Fix sim dropdown

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -350,7 +350,7 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 				return;
 			}
 			AddMessage(string.Format("Fetching download link for {0} ...", mSelectedPackages[mCurrentPackageIndex].Name));
-			string downloadUri = (ddlSim.SelectedText == "FSX") ? mSelectedPackages[mCurrentPackageIndex].AvsimUrlFsx : mSelectedPackages[mCurrentPackageIndex].AvsimUrlFs9;
+			string downloadUri = ((string)ddlSim.SelectedItem == "FSX") ? mSelectedPackages[mCurrentPackageIndex].AvsimUrlFsx : mSelectedPackages[mCurrentPackageIndex].AvsimUrlFs9;
 			mPackageDownloadClient.DownloadStringAsync(new Uri(downloadUri));
 		}
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -155,13 +155,24 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 					};
 					if (string.IsNullOrEmpty(pi.Country)) pi.Country = "N/A";
 					HtmlNodeCollection links = cells[5].SelectNodes("a");
-					if (links.Count == 2) {
-						pi.AvsimUrlFs9 = links[0].Attributes["href"].Value;
+                    List<HtmlAgilityPack.HtmlNode> avsimLinks = new List<HtmlAgilityPack.HtmlNode>();
+
+                    foreach (HtmlAgilityPack.HtmlNode link in links) {
+                        if (link.InnerText.ToLower().Trim() == "avsim") {
+                            avsimLinks.Add(link);
+                        }
+                    }
+
+                    if (avsimLinks.Count == 1) {
+                        pi.AvsimUrlFs9 = avsimLinks[0].Attributes["href"].Value;
 						pi.AvsimUrlFsx = pi.AvsimUrlFs9;
-					} else {
-						pi.AvsimUrlFs9 = links[0].Attributes["href"].Value;
-						pi.AvsimUrlFsx = links[2].Attributes["href"].Value;
-					}
+					} else if (avsimLinks.Count == 2) {
+                        pi.AvsimUrlFs9 = avsimLinks[0].Attributes["href"].Value;
+                        pi.AvsimUrlFsx = avsimLinks[1].Attributes["href"].Value;
+                    }
+                    else {
+                        MessageBox.Show(this, "Error finding AVSIM links for package: \"" + pi.Name + "\"", "Error", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
 					if (!mPackages[packageGroup.Name].ContainsKey(pi.Country)) mPackages[packageGroup.Name].Add(pi.Country, new List<PackageInfo>());
 					mPackages[packageGroup.Name][pi.Country].Add(pi);
 				}


### PR DESCRIPTION
Hi Ross,

I had some problems with the downloader out-of-the box. Even though I selected "FSX" as the target sim from the dropdown the downloader would download the FS9 versions of packages where multiple platforms were available. Upon inspection `ddlSim.SelectedText` was always equal to the empty string while ddlSim.SelectedItem contained the correct sim string. I've thus switched `SelectedText` to `SelectedItem` to solve this issue.

While debugging this I found that the link detection seemed a bit off and I wasn't convinced that the system was picking up the correct download link for each platform. Therefore I made some changes to how these links get scraped to make things hopefully a bit more obvious.

I'm new to the language and so won't be offended if you don't want to merge this as is. Please let me know if there's anything I can do to help.

My main concern here was being able to download the correct versions of packages which I was previously unable to do. The changes here allowed me to do that so hopefully they are useful to you :+1: .

Thanks for the great tool!
