### PR TITLE
Fixed issue with failing to download files from AVSIM

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -370,13 +370,8 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 					return;
 				}
 				string downloadUrl = string.Format(AVSIM_DOWNLOAD_URL_FORMAT, match.Groups[1].Value);
-				AddMessage("Fetching FTP URL ...");
-				mPackageDownloadClient.DownloadStringAsync(new Uri(downloadUrl));
-			} else {
 				AddMessage("Downloading file ...");
-				Uri ftpUri = new Uri(redirectUrl);
-				string filename = ftpUri.Segments.Last();
-				mPackageDownloadClient.DownloadFileAsync(ftpUri, Path.Combine(txtDownloadFolder.Text, filename));
+				mPackageDownloadClient.DownloadFileAsync(new Uri(downloadUrl), Path.Combine(txtDownloadFolder.Text, filename));
 			}
 		}
 


### PR DESCRIPTION
At the time of writing, it appears that AVSIM have modified their file library
so that the sendfile.php endpoint sends the actual file to the user agent
rather than redirecting to an FTP URL.

This commit removes the step in obtaining the FTP URL and directly saves the
output from the sendfile.php endpoint.
