### PR TITLE
Fix filename not found and allow redirects to the new location of the files

### DIFF
--- a/CookieAwareWebClient.cs
+++ b/CookieAwareWebClient.cs
@@ -17,7 +17,7 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 			var request = base.GetWebRequest(address);
 			if (request is HttpWebRequest) {
 				(request as HttpWebRequest).CookieContainer = CookieContainer;
-				(request as HttpWebRequest).AllowAutoRedirect = false;
+				(request as HttpWebRequest).AllowAutoRedirect = true;
 			}
 
 			return request;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -436,7 +436,7 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 				return;
 			}
 			string filenameHeader = mPackageDownloadClient.ResponseHeaders["Content-Disposition"] ?? string.Empty;
-			Match match = Regex.Match(filenameHeader, "filename=\"(.+?)\"", RegexOptions.IgnoreCase);
+			Match match = Regex.Match(filenameHeader, "filename=(.+)", RegexOptions.IgnoreCase);
 			if (!match.Success) {
 				AddErrorMessage(" filename not found in response headers." + Environment.NewLine);
 				DownloadNextPackage();

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -436,7 +436,7 @@ namespace Metacraft.FlightSimulation.WoaiDownloader
 				return;
 			}
 			string filenameHeader = mPackageDownloadClient.ResponseHeaders["Content-Disposition"] ?? string.Empty;
-			Match match = Regex.Match(filenameHeader, "filename=(.+)", RegexOptions.IgnoreCase);
+			Match match = Regex.Match(filenameHeader, "filename=\"?([^\"]+)", RegexOptions.IgnoreCase);
 			if (!match.Success) {
 				AddErrorMessage(" filename not found in response headers." + Environment.NewLine);
 				DownloadNextPackage();


### PR DESCRIPTION
The AVSIM_DOWNLOAD_URL_FORMAT that is being used in MainForm.cs no longer is the location of the file, rather returns the new location of the file in the ResponseHeaders. To fix this, the WebClient allows redirects so that it will automatically download from the new location of the files, which also gives back the correct headers. This means that the byte array will be able to actually pull data instead of just having nothing and returning bad headers. Also, the Regex.Match that finds the filename, was no longer working, so I got rid of the quotes and made it become greedy instead of lazy so that it returns the full filename. Now the "filename not found in response headers." error is no longer a thing, and it works just like it did a few months ago before avsim changed some stuff around.